### PR TITLE
[Refactor] Board 엔티티 수직 분할 진행

### DIFF
--- a/backend/ricecake/src/main/java/project/ricecake/board/controller/BoardController.java
+++ b/backend/ricecake/src/main/java/project/ricecake/board/controller/BoardController.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import project.ricecake.board.domain.request.PostCreateBoardReq;
 import project.ricecake.board.service.BoardService;

--- a/backend/ricecake/src/main/java/project/ricecake/board/domain/entity/BoardContent.java
+++ b/backend/ricecake/src/main/java/project/ricecake/board/domain/entity/BoardContent.java
@@ -1,0 +1,57 @@
+package project.ricecake.board.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * BoardContent
+ * DB에 저장할 게시글 정보를 담을 클래스
+ */
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BoardContent {
+
+    @Id
+    @Column(name = "board_idx", nullable = false)
+    private Long boardIdx;
+
+    @Lob
+    @Column(name = "board_content", nullable = false, length = 256)
+    private String boardContent;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "board_Idx")
+    private BoardEntity board;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    /**
+     * DB에 저장할 BoardContent 객체를 생성
+     * @param boardContent  (게시글 내용)
+     * @param board         (연관관계 주입을 위한 게시글 객체)
+     * @return BoardContent 객체
+     */
+    public static BoardContent buildBoardContent(String boardContent, BoardEntity board) {
+        return BoardContent.builder()
+                .boardContent(boardContent)
+                .board(board)
+                .build();
+    }
+}

--- a/backend/ricecake/src/main/java/project/ricecake/board/domain/entity/BoardEntity.java
+++ b/backend/ricecake/src/main/java/project/ricecake/board/domain/entity/BoardEntity.java
@@ -34,11 +34,6 @@ public class BoardEntity {
     @Column(name = "board_title", nullable = false, length = 30)
     private String boardTitle;
 
-    // TODO: text 타입에 대해서 공부 필요
-    @Lob
-    @Column(name = "board_content", nullable = false, length = 256)
-    private String boardContent;
-
     @CreationTimestamp
     @Column(name = "started_at", nullable = false)
     private LocalDateTime startedAt;
@@ -54,6 +49,9 @@ public class BoardEntity {
     @OneToMany(mappedBy = "commentIdx", fetch = FetchType.LAZY)
     private List<CommentEntity> comments = new ArrayList<>();
 
+    @OneToOne(mappedBy = "board")
+    private BoardContent boardContent;
+
     /**
      * DB에 저장할 BoardEntity 객체를 생성
      * @param postCreateBoardReq (게시글 생성 요청 DTO)
@@ -63,7 +61,6 @@ public class BoardEntity {
     public static BoardEntity buildBoard(PostCreateBoardReq postCreateBoardReq, MemberEntity member) {
         return BoardEntity.builder()
                 .boardTitle(postCreateBoardReq.getBoardTitle())
-                .boardContent(postCreateBoardReq.getBoardContent())
                 .member(member)
                 .build();
     }

--- a/backend/ricecake/src/main/java/project/ricecake/board/domain/response/GetBoardListRes.java
+++ b/backend/ricecake/src/main/java/project/ricecake/board/domain/response/GetBoardListRes.java
@@ -1,9 +1,12 @@
 package project.ricecake.board.domain.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 /**
  * GetBoardListRes
@@ -17,26 +20,25 @@ public class GetBoardListRes {
     @Size(max = 30, message = "게시글 제목은 최대 30자까지 가능합니다.")
     private String boardTitle;
 
-    @NotBlank(message = "게시글은 공백일 수 없습니다.")
-    @Size(max = 500, message = "게시글 내용은 최대 500자까지 가능합니다.")
-    private String boardContent;
-
     @NotBlank(message = "회원 아이디는 공백일 수 없습니다.")
     @Size(min = 2, max = 20, message = "회원의 이름은 최소 2자부터 최대 20자까지 가능합니다.")
     private String memberName;
 
+    @NotBlank(message = "게시글 생성 시간은 공백일 수 없습니다.")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDateTime startedAt;
+
     /**
      * GetBoardListRes 객체 생성
      * @param boardTitle (게시글 제목)
-     * @param boardContent (게시글 내용)
      * @param memberName (작성자 회원 이름)
      * @return GetBoardListRes 객체
      */
-    public static GetBoardListRes buildBoardListRes(String boardTitle, String boardContent, String memberName) {
+    public static GetBoardListRes buildBoardListRes(String boardTitle, String memberName, LocalDateTime startedAt) {
         return GetBoardListRes.builder()
                 .boardTitle(boardTitle)
-                .boardContent(boardContent)
                 .memberName(memberName)
+                .startedAt(startedAt)
                 .build();
     }
 }

--- a/backend/ricecake/src/main/java/project/ricecake/board/domain/response/GetBoardRes.java
+++ b/backend/ricecake/src/main/java/project/ricecake/board/domain/response/GetBoardRes.java
@@ -1,9 +1,12 @@
 package project.ricecake.board.domain.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 /**
  * GetBoardRes
@@ -25,6 +28,10 @@ public class GetBoardRes {
     @Size(min = 2, max = 20, message = "회원의 이름은 최소 2자부터 최대 20자까지 가능합니다.")
     private String memberName;
 
+    @NotBlank(message = "게시글 생성 시간은 공백일 수 없습니다.")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDateTime createdAt;
+
     /**
      * GetBoardRes 객체 생성
      * @param boardTitle (게시글 제목)
@@ -32,11 +39,12 @@ public class GetBoardRes {
      * @param memberName (작성자 회원 이름)
      * @return GetBoardRes 객체
      */
-    public static GetBoardRes buildBoardRes(String boardTitle, String boardContent, String memberName) {
+    public static GetBoardRes buildBoardRes(String boardTitle, String boardContent, String memberName, LocalDateTime createdAt) {
         return GetBoardRes.builder()
                 .boardTitle(boardTitle)
                 .boardContent(boardContent)
                 .memberName(memberName)
+                .createdAt(createdAt)
                 .build();
     }
 }

--- a/backend/ricecake/src/main/java/project/ricecake/board/repository/BoardContentRepository.java
+++ b/backend/ricecake/src/main/java/project/ricecake/board/repository/BoardContentRepository.java
@@ -1,0 +1,9 @@
+package project.ricecake.board.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import project.ricecake.board.domain.entity.BoardContent;
+
+@Repository
+public interface BoardContentRepository extends JpaRepository<BoardContent, Long> {
+}


### PR DESCRIPTION
- 게시글 목록 조회 성능을 높이기 위해 기존의 Board 엔티티를 수직 분할 진행
- 게시글 내용만 담은 BoardContent 엔티티를 새로 생성